### PR TITLE
Support multi-digit kanji numerals

### DIFF
--- a/src/qa_shu_utils.py
+++ b/src/qa_shu_utils.py
@@ -397,6 +397,20 @@ KANJI_NUM_MAP = {
 }
 
 
+def kanji_to_int(text: str) -> int:
+    """Convert simple Kanji numerals (<=99) to integer."""
+    if not text:
+        return 0
+    if text == "十":
+        return 10
+    if "十" in text:
+        tens_part, _, ones_part = text.partition("十")
+        tens = 1 if tens_part == "" else KANJI_NUM_MAP.get(tens_part, 0)
+        ones = 0 if ones_part == "" else KANJI_NUM_MAP.get(ones_part, 0)
+        return tens * 10 + ones
+    return KANJI_NUM_MAP.get(text, 0)
+
+
 def extract_submitter_count(text: Optional[str]) -> int:
     """
     提出者数を算出（主提出者 + 外〇名）。
@@ -413,8 +427,8 @@ def extract_submitter_count(text: Optional[str]) -> int:
     """
     if not text:
         return 0
-    m = re.search(r"外([零〇一二三四五六七八九十])名", text)
-    extra = KANJI_NUM_MAP.get(m.group(1), 0) if m else 0
+    m = re.search(r"外([零〇一二三四五六七八九十]+)名", text)
+    extra = kanji_to_int(m.group(1)) if m else 0
     return 1 + extra
 
 

--- a/tests/test_qa_shu_utils.py
+++ b/tests/test_qa_shu_utils.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import types
+import pytest
+
+# Stub external dependencies not installed in the test environment
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+bs4_stub = types.ModuleType("bs4")
+bs4_stub.BeautifulSoup = object
+sys.modules.setdefault("bs4", bs4_stub)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.qa_shu_utils import extract_submitter_count
+
+@pytest.mark.parametrize("text,expected", [
+    ("原口　一博君外二名", 3),
+    ("田中　太郎君", 1),
+    ("佐藤　太郎君外十一名", 12),
+    ("佐藤　太郎君外十二名", 13),
+])
+def test_extract_submitter_count(text, expected):
+    assert extract_submitter_count(text) == expected


### PR DESCRIPTION
## Summary
- support multi-digit kanji numerals when parsing submitter counts
- add helper to convert kanji numerals to integers
- test submitter counts including "外十一名" and "外十二名"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849122c41c48333a2cebdb3a8851c69