### PR TITLE
Move Sangiin classes to central models

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -55,3 +55,19 @@ class ShuShitsumonStatus(BaseModel):
     withdrawal_date: Optional[str]
     withdrawal_notice_date: Optional[str]
     status: Optional[str]
+
+
+class SangiinShitsumonData(BaseModel):
+    number: Optional[int] = Field(None)
+    question_subject: Optional[str] = Field(None)
+    submitter_name: Optional[str] = Field(None)
+    question_html_link: Optional[str] = Field(None)
+    question_pdf_link: Optional[str] = Field(None)
+    answer_html_link: Optional[str] = Field(None)
+    answer_pdf_link: Optional[str] = Field(None)
+
+
+class SangiinShitsumonList(BaseModel):
+    session: int
+    source: str
+    items: List[SangiinShitsumonData]

--- a/src/qa_san_utils.py
+++ b/src/qa_san_utils.py
@@ -5,24 +5,7 @@ from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
-from pydantic import BaseModel, Field  # ← Fieldをインポート
-
-
-class SangiinShitsumonData(BaseModel):
-    number: Optional[int] = Field(None)
-    question_subject: Optional[str] = Field(None)
-    submitter_name: Optional[str] = Field(None)
-    question_html_link: Optional[str] = Field(None)
-    question_pdf_link: Optional[str] = Field(None)
-    answer_html_link: Optional[str] = Field(None)
-    answer_pdf_link: Optional[str] = Field(None)
-
-
-class SangiinShitsumonList(BaseModel):
-    session: int
-    source: str
-    items: List[SangiinShitsumonData]
-
+from src.models import SangiinShitsumonData, SangiinShitsumonList
 
 def get_session_url(session: int) -> str:
     return (


### PR DESCRIPTION
## Summary
- define `SangiinShitsumonData` and `SangiinShitsumonList` in `src/models.py`
- refactor `qa_san_utils` to import these classes instead of defining them locally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684914904ec483339b6f8758c90f2957