### PR TITLE
参議院QA取得処理の改善

### DIFF
--- a/qa_san.py
+++ b/qa_san.py
@@ -175,8 +175,11 @@ def process_session(session: int, idx: int, total: int, force_latest: bool = Fal
     # 各質問の経過状況保存
     for q in data.items:
         print(f"    ▷ ステータス保存: question_id={q.number}")
+        from src.qa_san_utils import status_is_received
+
+        force = force_latest or not status_is_received(session, q.number)
         save_status_if_needed(
-            session, q.number, q.progress_info_link, wait, force_latest
+            session, q.number, q.progress_info_link, wait, force
         )
 
 


### PR DESCRIPTION
## Summary
- 参議院の質問主意書において既存ステータスが答弁受理でない場合のみ
  質問・答弁・経過状況を再取得するように変更

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492c41a4e08333afccd9ea65b7f92c